### PR TITLE
Fix Sticker endpoint

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -33,6 +33,7 @@ var (
 	EndpointWebhooks       = EndpointAPI + "webhooks/"
 	EndpointStickers       = EndpointAPI + "stickers/"
 	EndpointStageInstances = EndpointAPI + "stage-instances"
+	EndpointStickerImages  = EndpointDiscord + "stickers/"
 
 	EndpointCDN             = "https://cdn.discordapp.com/"
 	EndpointCDNAttachments  = EndpointCDN + "attachments/"
@@ -152,7 +153,7 @@ var (
 		case StickerFormatTypeGIF:
 			ext = ".gif"
 		}
-		return EndpointCDNStickers + sID + ext
+		return EndpointStickerImages + sID + ext
 	}
 	EndpointNitroStickersPacks = EndpointAPI + "/sticker-packs"
 


### PR DESCRIPTION
Sticker endpoints under `cdn.` are returning access denied. Demo: https://cdn.discordapp.com/stickers/796140638093443092.json

Looking at the developer console while using discord on chrome shows that stickers are being loaded with URLs like: https://discord.com/stickers/776243172258611200.json

This change works and has been tested.