### PR TITLE
wsapi: send standard Op 1 heartbeat for bot sessions

### DIFF
--- a/wsapi.go
+++ b/wsapi.go
@@ -336,18 +336,11 @@ func (s *Session) listen(ctx context.Context, wsConn *websocket.Conn, listening 
 	}
 }
 
-// heartbeatOp is the standard gateway Op 1 heartbeat payload.
 type heartbeatOp struct {
 	Op   int   `json:"op"`
 	Data int64 `json:"d"`
 }
 
-// newHeartbeatOp returns the heartbeat payload for this session type. Bot
-// sessions must send the standard Op 1: since 2026-08-07 Discord rejects the
-// client-internal Op 40 QoS heartbeat on bot connections with close 4002
-// ("Error while decoding payload"), which puts the session in a reconnect
-// loop that trips the session start limit and gets the bot token reset.
-// User sessions keep the QoS heartbeat that the official client sends.
 func (s *Session) newHeartbeatOp(seq int64) interface{} {
 	if s.IsUser {
 		return newForegroundedQosHeartbeatOp(seq)

--- a/wsapi.go
+++ b/wsapi.go
@@ -336,6 +336,25 @@ func (s *Session) listen(ctx context.Context, wsConn *websocket.Conn, listening 
 	}
 }
 
+// heartbeatOp is the standard gateway Op 1 heartbeat payload.
+type heartbeatOp struct {
+	Op   int   `json:"op"`
+	Data int64 `json:"d"`
+}
+
+// newHeartbeatOp returns the heartbeat payload for this session type. Bot
+// sessions must send the standard Op 1: since 2026-08-07 Discord rejects the
+// client-internal Op 40 QoS heartbeat on bot connections with close 4002
+// ("Error while decoding payload"), which puts the session in a reconnect
+// loop that trips the session start limit and gets the bot token reset.
+// User sessions keep the QoS heartbeat that the official client sends.
+func (s *Session) newHeartbeatOp(seq int64) interface{} {
+	if s.IsUser {
+		return newForegroundedQosHeartbeatOp(seq)
+	}
+	return heartbeatOp{Op: 1, Data: seq}
+}
+
 func newForegroundedQosHeartbeatOp(seq int64) qosHeartbeatOp {
 	return qosHeartbeatOp{
 		Op: 40,
@@ -414,7 +433,7 @@ func (s *Session) heartbeat(ctx context.Context, wsConn *websocket.Conn, listeni
 		s.log(LogDebug, "sending gateway websocket heartbeat seq %d", sequence)
 		s.wsMutex.Lock()
 		s.LastHeartbeatSent = time.Now().UTC()
-		err = wsjson.Write(ctx, wsConn, newForegroundedQosHeartbeatOp(sequence))
+		err = wsjson.Write(ctx, wsConn, s.newHeartbeatOp(sequence))
 		s.wsMutex.Unlock()
 		if err != nil || time.Now().UTC().Sub(last) > (heartbeatIntervalMsec*FailedHeartbeatAcks) {
 			if err != nil {
@@ -780,7 +799,7 @@ func (s *Session) onEvent(messageType websocket.MessageType, message []byte, isO
 	if e.Operation == 1 {
 		s.log(LogInformational, "sending heartbeat in response to Op1")
 		s.wsMutex.Lock()
-		err = wsjson.Write(s.wsConnCtx, s.wsConn, newForegroundedQosHeartbeatOp(atomic.LoadInt64(s.sequence)))
+		err = wsjson.Write(s.wsConnCtx, s.wsConn, s.newHeartbeatOp(atomic.LoadInt64(s.sequence)))
 		s.wsMutex.Unlock()
 		if err != nil {
 			s.log(LogError, "error sending heartbeat in response to Op1")


### PR DESCRIPTION
Hi there, thank you for maintaining this great discordgo fork! I've used it before for personal projects and by using the Matrix/Discord bridge for [ntfy](https://github.com/binwiederhier/ntfy) ([ntfy.sh](https://ntfy.sh)). This morning, the bridge started complaining and Discord revoked the bot token after 1000 tries.

I dispatched Claude to figure it out and it fixed it in my instance. Here's a doc that described what it did: https://gist.github.com/binwiederhier/a252892ccc05af7412119643aac39e31

This PR is the fix Claude suggested. I do not pretend to understand what this is, but I figured it may be helpful. Other people in `#discord:maunium.net` have the same issues. So it's not just me :-)

Claude's comments:

> Since 2026-08-07 Discord's gateway rejects the client-internal Op 40 QoS heartbeat on bot connections, closing the websocket with 4002 ("Error while decoding payload") at the first heartbeat after READY. The session then reconnect-loops, trips the 1000-connection session start limit, and Discord force-resets the bot token.
> 
> Send the standard Op 1 heartbeat for bot sessions and keep the QoS heartbeat for user sessions, which the first-party client still uses.
> 
> Verified against the live gateway with a minimal bot: unpatched (both at the v0.7.6 pin and at current HEAD, qos ver 26 and 28) the session dies at the first heartbeat; with this change it stays connected.